### PR TITLE
Restrict IPFS API to loopback, drop wildcard CORS+credentials

### DIFF
--- a/bin/ipfs-bin-container_daemon.sh
+++ b/bin/ipfs-bin-container_daemon.sh
@@ -18,13 +18,12 @@ if [ -e "$repo/config" ]; then
   echo "Found IPFS fs-repo at $repo"
 else
   ipfs init
-  ipfs config Addresses.API /ip4/0.0.0.0/tcp/5001
+  # SECURITY FIX (2026-06-29 audit): see bin/launch.sh for full rationale —
+  # the unauthenticated IPFS API was bound to 0.0.0.0 with wildcard CORS +
+  # credentials, giving unauthenticated full read/write/admin node control
+  # to anyone who could reach the host. Bound to loopback only; no CORS set.
+  ipfs config Addresses.API /ip4/127.0.0.1/tcp/5001
   ipfs config Addresses.Gateway /ip4/0.0.0.0/tcp/8080
-  # See https://github.com/ipfs/js-ipfs-api#cors for more refining policies on
-  # acceptable URLs (CORS = Cross Origin Resource Sharing)
-  # The following policy creates SECURITY BREACH!!!!!!!!!!
-  ipfs config --json API.HTTPHeaders.Access-Control-Allow-Origin "[\"*\"]"
-  ipfs config --json API.HTTPHeaders.Access-Control-Allow-Credentials "[\"true\"]"
 fi
 
 # if the first argument is daemon

--- a/bin/launch.sh
+++ b/bin/launch.sh
@@ -5,13 +5,21 @@ source /etc/profile.d/go_path.sh
 
 ipfs init
 ipfs config Addresses.Gateway /ip4/0.0.0.0/tcp/8080
-ipfs config Addresses.API /ip4/0.0.0.0/tcp/5001
-# See https://github.com/ipfs/js-ipfs-api#cors for more refining policies on
-# acceptable URLs (CORS = Cross Origin Resource Sharing)
-# The following policy creates SECURITY BREACH!!!!!!!!!!
-# TODO: Fix this
-ipfs config --json API.HTTPHeaders.Access-Control-Allow-Origin "[\"*\"]"
-ipfs config --json API.HTTPHeaders.Access-Control-Allow-Credentials "[\"true\"]"
+# SECURITY FIX (2026-06-29 audit): API was previously bound to 0.0.0.0 with
+# Access-Control-Allow-Origin "*" + Allow-Credentials "true" — the original
+# "TODO: Fix this / SECURITY BREACH" comment below was never acted on. The
+# IPFS API is the full read/write/admin interface (pin, add, config, shutdown,
+# swarm, etc.) with no authentication of its own. Binding it to 0.0.0.0 plus a
+# wildcard+credentials CORS policy meant any website in any visitor's browser,
+# or anyone who could reach the host on the network, had unauthenticated full
+# control of the node. Fixed by binding to loopback only; if a host process or
+# reverse proxy needs to reach this from outside the container, do it via an
+# authenticated, narrowly-scoped proxy — do not restore 0.0.0.0 or wildcard CORS.
+ipfs config Addresses.API /ip4/127.0.0.1/tcp/5001
+# No CORS headers are set: the API is loopback-only now. If a specific trusted
+# origin genuinely needs cross-origin access, set Access-Control-Allow-Origin
+# to that exact origin (never "*") and only pair it with Allow-Credentials if
+# that origin is fully trusted — do not reinstate the wildcard.
 ipfs daemon &
 
 set +a


### PR DESCRIPTION
Security audit finding (2026-06-29): the IPFS API (port 5001 -- full read/write/admin interface, no auth of its own) was bound to 0.0.0.0 with Access-Control-Allow-Origin '*' + Access-Control-Allow-Credentials 'true'. The original comment above this code already called it out as a 'SECURITY BREACH' with a TODO to fix it, never acted on. Bound the API to 127.0.0.1 and removed the wildcard CORS config; the public read-only Gateway (port 8080) is untouched. Branched off master (not the in-flight crypto-js-4 security branch) to keep this fix's PR diff isolated. See BMD-IPFS-ES-Public-Exposure-Assessment-2026-06-29.md in the audit folder for the full writeup (this also affects bc-ipfs-node, bc-ipfs, and BMD-ansible-deployment's published_ports + nginx.conf, patched separately).