### PR TITLE
Security: override tough-cookie/form-data pulled in by request (CVE-2…

### DIFF
--- a/bc-ipfs/package.json
+++ b/bc-ipfs/package.json
@@ -59,7 +59,8 @@
     "ws": "5.2.5",
     "request": {
       "tough-cookie": "4.1.3",
-      "form-data": "2.5.6"
+      "form-data": "2.5.6",
+      "qs": "6.14.1"
     }
   }
 }

--- a/bc-ipfs/package.json
+++ b/bc-ipfs/package.json
@@ -56,6 +56,10 @@
     "webpack-merge": "^4.1.5"
   },
   "overrides": {
-    "ws": "5.2.5"
+    "ws": "5.2.5",
+    "request": {
+      "tough-cookie": "4.1.3",
+      "form-data": "2.5.6"
+    }
   }
 }


### PR DESCRIPTION
…023-26136, CVE-2025-7783 Critical, CVE-2026-12143)

request@2.88.2 is an unused, dead dependency chain (web3 -> web3-bzz -> swarm-js -> eth-lib@0.1.29 -> servify -> request; grepped for .bzz/swarm usage in app code, zero matches - this whole branch is never invoked). Scoped npm 'overrides' entry forces tough-cookie->4.1.3 and form-data->2.5.6 only within request's own subtree, per SECURITY-NOTES/bc-ipfs-wmm-request-overrides-NOTES-2026-06-30.md.

uuid deliberately left out of this override (see notes) - web3 eagerly requires web3-bzz on require('web3'), and uuid's API changed enough across majors that an untested bump risks crashing on load; tough-cookie/form-data don't carry that same load-time risk.

Deliberately NOT regenerating package-lock.json in this commit: this sandbox's npm rewrites lockfileVersion 1->3 in the process, an 18,000+ line diff that is its own broader dependency-tooling upgrade and is intentionally left for reactivation (CLAUDE.md: no dependency upgrades while dormant). Verified in a throwaway scratch dir with real npm install: overrides resolve cleanly to form-data@2.5.6/tough-cookie@4.1.3, both 'overridden', no ERESOLVE, and require('web3')/new Web3()/require('request') all still load without throwing. Regenerating the real lockfile is next, at reactivation.