### PR TITLE
Security: override tar and the html-webpack-plugin copy of loader-utils

### DIFF
--- a/bc-ipfs/package.json
+++ b/bc-ipfs/package.json
@@ -56,6 +56,10 @@
     "webpack-merge": "^4.1.5"
   },
   "overrides": {
-    "ws": "5.2.5"
+    "ws": "5.2.5",
+    "tar": "6.2.1",
+    "html-webpack-plugin": {
+      "loader-utils": "1.4.1"
+    }
   }
 }


### PR DESCRIPTION
tar@4.4.19 (CVE-2026-23745/-23950/-24842/-26960/-29786, arbitrary-file-write class) is required only by swarm-js@0.1.42 - the same confirmed-dead web3 -> web3-bzz -> swarm-js/.bzz chain already documented in the request override (PR #20). loader-utils@0.2.17 (CVE-2022-37601, Critical despite being dev-only) is required only by html-webpack-plugin@3.2.0 (^0.2.16, the old 0.x line); every other consumer in the tree already resolves to the clean 1.4.2 copy. Both are build-time only - a break here fails the build loudly, not a silent runtime issue.

node-forge deliberately left OUT of this commit even though it was in the original draft patch (SECURITY-NOTES/bc-ipfs-wmm-priority-bumps-2026-06-30.patch) alongside these two: it's pulled in by libp2p-crypto/peer-id for real RSA key PEM/ASN.1 conversion on the live IPFS peer-id path, both hard-pinned to ^0.10.0, and needs an RSA round-trip smoke test before treating a 0.10->1.0 major bump as safe. Tracking that separately.

Verified with a real npm install in a throwaway scratch copy: resolves cleanly to tar@6.2.1 and html-webpack-plugin's nested loader-utils@1.4.1 (the sibling top-level copy stays at its already-clean 1.4.2), no ERESOLVE. Not regenerating package-lock.json here, same reasoning as PR #20 - that's its own lockfileVersion 1->3 dependency-tooling upgrade, parked for reactivation per CLAUDE.md.