### PR TITLE
Security: bump webpack-dev-server, override webpack-dev-middleware/ht…

### DIFF
--- a/bc-ipfs/package.json
+++ b/bc-ipfs/package.json
@@ -52,10 +52,15 @@
     "uglifyjs-webpack-plugin": "^2.1.0",
     "webpack": "^4.28.2",
     "webpack-cli": "^3.1.2",
-    "webpack-dev-server": "^3.11.3",
+    "webpack-dev-server": "^4.15.2",
     "webpack-merge": "^4.1.5"
   },
   "overrides": {
-    "ws": "5.2.5"
+    "ws": "5.2.5",
+    "webpack-dev-middleware": "5.3.4",
+    "http-proxy-middleware": "2.0.10",
+    "uglifyjs-webpack-plugin": {
+      "serialize-javascript": "4.0.0"
+    }
   }
 }


### PR DESCRIPTION
…tp-proxy-middleware/serialize-javascript (dev-only, does not touch the production build)

Confirmed via package.json scripts: 'build' runs webpack directly against webpack.live.js and never touches webpack-dev-server; only 'test'/'start' do. Worst case if something here breaks: local hot-reload/dev workflow, not the deployed app.

Correction from the original draft (SECURITY-NOTES/bc-ipfs-wmm-devtooling-safe-2026-06-30.patch, which bumped webpack-dev-server to ^5.2.1): that version requires webpack ^5.0.0 as a peer, and this project is still pinned to webpack ^4.28.2 (resolves to 4.47.0) - confirmed the ERESOLVE conflict with a real npm install in this session (something the original draft couldn't check, no registry access at the time). Bumped to ^4.15.2 instead - the newest 4.x release, still on webpack-dev-server's ^4.37.0-or-^5.0.0 peer range, compatible with the installed webpack@4.47.0. webpack-dev-middleware and http-proxy-middleware are transitive (pulled in by webpack-dev-server itself) and scoped-overridden as a safety net.

serialize-javascript's vulnerable 1.9.1 copy came from uglifyjs-webpack-plugin@2.2.0, a devDependency that's dead weight - grepped all four webpack config files, uglifyjs-webpack-plugin is never require()'d or referenced; this build's only configured minimizer is OptimizeCSSAssetsPlugin (CSS only, JS is currently unminified, a separate pre-existing fact not touched here).

micromatch@3.1.10 -> 4.0.8 deliberately left OUT of this commit, unlike the original draft: it's required directly by webpack@4.47.0 itself for internal glob matching, used in every build including 'npm run build', so it needs a real build to verify rather than trusting it's silent-safe like the items above. Attempted that verification this session - blocked by an unrelated sandbox limitation (node-gyp needs to download Node headers from nodejs.org/download, not on this sandbox's network allowlist, to compile the native 'bufferutil' addon) - not something this override caused. Tracking micromatch separately until a real 'npm run build' can confirm it.

postcss/cssnano intentionally not touched, same reasoning as the original notes (SECURITY-NOTES/bc-ipfs-wmm-devtooling-NOTES-2026-06-30.md) - forcing postcss alone to 8.x would hand it to 25+ plugins that only support the postcss 7 plugin API and would very likely break CSS minification outright.

Verified with a real npm install (package-lock-only) in a throwaway scratch copy: resolves cleanly to webpack-dev-server@4.15.2, webpack-dev-middleware@5.3.4, http-proxy-middleware@2.0.10, serialize-javascript@4.0.0, no ERESOLVE. Not regenerating the real package-lock.json here, same reasoning as PR #20/#21.