### PR TITLE
Security: override bn.js duplicate copy, uuid in sockjs/webpack-log (…

### DIFF
--- a/bc-ipfs/package.json
+++ b/bc-ipfs/package.json
@@ -56,6 +56,13 @@
     "webpack-merge": "^4.1.5"
   },
   "overrides": {
-    "ws": "5.2.5"
+    "ws": "5.2.5",
+    "bn.js": "4.12.3",
+    "sockjs": {
+      "uuid": "11.1.1"
+    },
+    "webpack-log": {
+      "uuid": "11.1.1"
+    }
   }
 }


### PR DESCRIPTION
…dev-only chain)

bn.js@4.11.6 (CVE-2026-2739) is required by ethjs-unit@0.1.6 and number-to-bn@1.7.0, both with a hardcoded exact pin '4.11.6' - not a range, so plain 'npm dedupe' can't touch it. Every other consumer in the tree already wants ^4.x/^5.x ranges unaffected by this override. Same-major patch release (4.11.6 -> 4.12.3), not an API-breaking jump, but it does override an exact pin the original packages never asked for.

uuid in sockjs/webpack-log: both are only required by the webpack-dev-server/webpack-dev-middleware dev-only chain (same one bumped in the earlier webpack-devtooling PR). Overridden to 11.1.1. Deliberately NOT touching web3-eth-accounts's separate uuid@9.0.1 copy here - that one is live wallet-keystore code (lib/index.js:488,
uuid.v4({random: cryp.randomBytes(16)})), not dev tooling, and per SECURITY-NOTES/bc-ipfs-wmm-babel-and-housekeeping-NOTES-2026-06-30.md it needs its own dedicated verification rather than being silently folded into a housekeeping commit. Tracking that as a separate change.

Verified with a real npm install in a throwaway scratch copy: bn.js resolves cleanly to 4.12.3 (the 5.x copies elsewhere are untouched, already clean), sockjs/webpack-log resolve to uuid@11.1.1, no ERESOLVE. Also ran the numeric sanity check the original notes recommended but couldn't run themselves (no registry access at the time): installed bn.js@4.12.3 standalone and converted a known value (1 ether = 10^18 wei -> 10^9 gwei, and its hex representation) - correct output, matches expected values.