### PR TITLE
Security: override uuid in web3-eth-accounts (CVE-2026-41907) - narro…

### DIFF
--- a/bc-ipfs/package.json
+++ b/bc-ipfs/package.json
@@ -56,6 +56,9 @@
     "webpack-merge": "^4.1.5"
   },
   "overrides": {
-    "ws": "5.2.5"
+    "ws": "5.2.5",
+    "web3-eth-accounts": {
+      "uuid": "11.1.1"
+    }
   }
 }


### PR DESCRIPTION
…w verification only, review before merging

Deliberately kept separate from the other housekeeping overrides (bn.js/sockjs/webpack-log, see the other open PR) per SECURITY-NOTES/bc-ipfs-wmm-babel-and-housekeeping-NOTES-2026-06-30.md's own instruction: this is live wallet-keystore code, not dead/dev-only code, and should not be silently bundled into a routine housekeeping commit.

The call site (web3-eth-accounts@1.10.4, lib/index.js:488) does uuid.v4({ random: cryp.randomBytes(16) }) - the old default-export-with- options calling style, inside the V3 keystore-encryption path (wallet file generation). The original notes flagged this as untestable at the time (no registry access). This session has registry access, so ran the exact one-line compatibility test the notes prescribed:

    const uuid = require('uuid');
    uuid.v4({ random: Buffer.alloc(16, 7) })
    // => '07070707-0707-4707-8707-070707070707', no throw

against a standalone uuid@11.1.1 install - passes, confirms the calling convention the code depends on still exists in 11.x. Also confirmed the override itself resolves cleanly (npm install --package-lock-only, web3-eth-accounts's copy -> 11.1.1, no ERESOLVE).

What this does NOT verify: an actual keystore encrypt/decrypt round trip, or that a wallet file generated with the old uuid@9.0.1 stays readable after this bump. The narrow call succeeding means the function doesn't crash and returns a UUID-shaped string - it doesn't prove byte-for-byte behavioral identity with the old version. Given this touches wallet keystore generation, recommend an actual round-trip test (generate a keystore with this override applied, confirm it can be decrypted with the expected password) before merging, not just trusting this commit.