### PR TITLE
Security: override node-forge 0.10.0 -> 1.0.0 (5 High CVEs, 8 more no…

### DIFF
--- a/bc-ipfs/package.json
+++ b/bc-ipfs/package.json
@@ -56,6 +56,7 @@
     "webpack-merge": "^4.1.5"
   },
   "overrides": {
-    "ws": "5.2.5"
+    "ws": "5.2.5",
+    "node-forge": "1.0.0"
   }
 }


### PR DESCRIPTION
…t individually shown)

Pulled in by libp2p-crypto@0.16.4 (via ipfs-http-client@28.1.2, a direct dependency of this app) and peer-id@0.12.5, both declaring node-forge: ^0.10.0 explicitly - their maintainers never tested 1.x, which is why the original notes (SECURITY-NOTES/bc-ipfs-wmm-priority-bumps-NOTES-2026-06-30.md) flagged this as needing an RSA round-trip smoke test before trusting it, unlike the dead-code overrides (tar/request/etc.) applied earlier tonight. This is runtime crypto for real IPFS peer-identity keys, not dead code.

Ran that smoke test this session (registry access available, wasn't at the time the notes were written) against every forge.pki/forge.asn1/ forge.jsbn function libp2p-crypto actually calls:

  - forge.pki.rsa.generateKeyPair
  - forge.pki.privateKeyToAsn1 / wrapRsaPrivateKey
  - forge.pki.setRsaPrivateKey (reconstruct from n/e/d/p/q/dP/dQ/qInv)
  - forge.pki.privateKeyToPem / publicKeyToPem
  - forge.pki.encryptRsaPrivateKey (passphrase-encrypted PEM) and forge.pki.decryptRsaPrivateKey - round-tripped, decrypted key's modulus matches the original exactly
  - forge.pki.setRsaPublicKey
  - forge.asn1.toDer / forge.asn1.fromDer round trip
  - forge.jsbn.BigInteger (add/multiply)

Beyond just calling each function without error, ran a full functional round trip: encrypted a message with a PEM-parsed public key (RSA-OAEP), decrypted it with the private key recovered from the passphrase-encrypted PEM, and confirmed the decrypted plaintext matches the original message exactly - not just that the API surface exists, that the actual cryptographic operations are correct.

Verified the override itself resolves cleanly too: npm install --package-lock-only in a throwaway scratch copy, node-forge -> 1.0.0, single top-level copy, no ERESOLVE.

Not regenerating package-lock.json in this commit, same reasoning as every other override tonight - that's its own lockfileVersion 1->3 dependency-tooling upgrade, parked for reactivation per CLAUDE.md.