### PR TITLE
Security 3/7: patch node-forge with runtime crypto test

### DIFF
--- a/bc-ipfs/package-lock.json
+++ b/bc-ipfs/package-lock.json
@@ -7384,11 +7384,12 @@
       }
     },
     "node_modules/node-forge": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
-      "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
+      "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
+      "license": "(BSD-3-Clause OR GPL-2.0)",
       "engines": {
-        "node": ">= 6.0.0"
+        "node": ">= 6.13.0"
       }
     },
     "node_modules/node-libs-browser": {

--- a/bc-ipfs/package.json
+++ b/bc-ipfs/package.json
@@ -5,6 +5,7 @@
   "private": true,
   "scripts": {
     "build": "export NODE_ENV=production; webpack -p --config webpack.live.js",
+    "test:crypto": "node scripts/test-libp2p-crypto.js",
     "test": "export NODE_ENV=development; echo NODE_ENV=$NODE_ENV; webpack-dev-server --config webpack.dev.js",
     "start": "export NODE_ENV=production; echo NODE_ENV=$NODE_ENV; webpack-dev-server --config webpack.prod.js"
   },
@@ -61,6 +62,7 @@
       "tough-cookie": "4.1.3",
       "form-data": "2.5.6",
       "qs": "6.14.1"
-    }
+    },
+    "node-forge": "1.3.1"
   }
 }

--- a/bc-ipfs/scripts/test-libp2p-crypto.js
+++ b/bc-ipfs/scripts/test-libp2p-crypto.js
@@ -1,0 +1,35 @@
+'use strict';
+
+const assert = require('assert');
+const { promisify } = require('util');
+const crypto = require('libp2p-crypto');
+
+async function main() {
+  const generateKeyPair = promisify(crypto.keys.generateKeyPair);
+  const importKey = promisify(crypto.keys.import);
+  const key = await generateKeyPair('RSA', 2048);
+  const message = Buffer.from('bc-ipfs-wmm node-forge compatibility');
+  const sign = promisify(key.sign.bind(key));
+  const verify = promisify(key.public.verify.bind(key.public));
+  const signature = await sign(message);
+
+  assert.strictEqual(await verify(message, signature), true);
+  assert.strictEqual(await verify(Buffer.from('tampered'), signature), false);
+
+  const password = 'local-compatibility-test';
+  const encryptedPem = await promisify(key.export.bind(key))(password);
+  const imported = await importKey(encryptedPem, password);
+  const importedSignature = await promisify(imported.sign.bind(imported))(message);
+
+  assert.strictEqual(
+    await promisify(imported.public.verify.bind(imported.public))(message, importedSignature),
+    true,
+  );
+  assert.deepStrictEqual(imported.public.bytes, key.public.bytes);
+  process.stdout.write('libp2p RSA generate/export/import/sign/verify: passed\n');
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- forces patched node-forge 1.3.1 through the legacy IPFS/libp2p tree
- adds an executable regression test against the exact callback-era libp2p-crypto API

## Verification
`npm run test:crypto` passes RSA-2048 key generation, encrypted PEM export/import, sign/verify, tamper rejection, and public-key equality.

## Stack
Depends on #27.