### PR TITLE
chore: group Dependabot security updates into a single PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,51 @@
+# Dependabot configuration for bc-ipfs-wmm.
+#
+# Goal: keep security coverage exactly as it is, but stop it arriving as one
+# pull request (and one email) per advisory.
+#
+# Before this file, the repo ran on defaults: Dependabot security updates were
+# enabled with no config, and the default is one PR per vulnerable dependency.
+# A batch of advisories therefore landed as a burst of near-identical PRs — on
+# 2026-07-25, #34 then #35 and #36, each triggering its own notification, and
+# each merge triggering a re-scan that produced the next one.
+#
+# Two things are set below:
+#
+#   groups.security-updates
+#     Collapses all npm security updates into a single grouped PR instead of one
+#     per package. Dependencies that do not match a group are still opened
+#     individually, so nothing is silently dropped.
+#
+#   open-pull-requests-limit: 0
+#     Disables *version* updates. Adding any dependabot.yml would otherwise turn
+#     them on for the first time, which would flood the repo with PRs for merely
+#     outdated packages. Security update PRs are explicitly not subject to this
+#     limit, so vulnerability coverage is unaffected.
+#
+# Net effect: same alerts, same fixes, far fewer PRs. To take up routine version
+# updates later, raise the limit and add a second group with
+# `applies-to: version-updates`.
+
+version: 2
+
+updates:
+  - package-ecosystem: "npm"
+    directory: "/bc-ipfs"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Etc/UTC"
+
+    # Version updates off; security updates are exempt from this limit.
+    open-pull-requests-limit: 0
+
+    groups:
+      security-updates:
+        applies-to: security-updates
+        patterns:
+          - "*"
+
+    labels:
+      - "dependencies"
+      - "security"


### PR DESCRIPTION
## Problem

The repo has no `dependabot.yml`, so Dependabot security updates run on defaults: **one PR per vulnerable dependency**. A batch of advisories therefore arrives as a burst of near-identical PRs, each with its own notification — and because every merge to `master` triggers a re-scan, merging one spawns the next.

Today that produced #34, then #35 and #36, in sequence.

## Change

Adds `.github/dependabot.yml` with a single group covering npm security updates, so they arrive as one PR:

```yaml
groups:
  security-updates:
    applies-to: security-updates
    patterns: ["*"]
```

Dependencies that don't match a group are still opened individually, so nothing gets silently dropped.

## Why `open-pull-requests-limit: 0`

This is the part worth a second look. Adding *any* `dependabot.yml` enables **version updates**, which this repo has never had — that would open PRs for merely outdated packages, making the noise worse rather than better. Setting the limit to `0` disables version updates.

Per [GitHub's reference](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#open-pull-requests-limit-): *"Security update pull requests are not subject to this limit and do not count toward it."* So security coverage is unchanged — same alerts, same fixes, fewer PRs.

To take up routine version updates later, raise the limit and add a second group with `applies-to: version-updates`.

## Verification

Config parses as valid YAML and matches the documented schema (`version: 2`, `package-ecosystem: npm`, `directory: /bc-ipfs` matching the manifest location, `groups.<name>.applies-to`). Actual grouping behaviour can only be confirmed by the next real security advisory.