### PR TITLE
security: pin fast-uri to 3.1.5 (CVE-2026-18446)

### DIFF
--- a/bc-ipfs/package-lock.json
+++ b/bc-ipfs/package-lock.json
@@ -5995,9 +5995,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "dev": true,
       "funding": [
         {

--- a/bc-ipfs/package.json
+++ b/bc-ipfs/package.json
@@ -58,6 +58,7 @@
     },
     "nanoid": "5.1.16",
     "parse-duration": "2.1.3",
-    "undici": "6.27.0"
+    "undici": "6.27.0",
+    "fast-uri": "3.1.5"
   }
 }


### PR DESCRIPTION
## Summary

Pins `fast-uri` to `3.1.5` to close **CVE-2026-18446** / **GHSA-7p8r-x3mc-p8w7** (High, CVSS 7.5) in `bc-ipfs`. Closes Dependabot alert #258.

`fast-uri` requires a literal `//` to recognise a URI authority, so `\\host`, `/\host` and `\/host` parse with no authority. Node's WHATWG URL treats those as host-introducing for special schemes (http/https). A validator on one parser and a fetcher on the other can therefore disagree about the host, which is what breaks SSRF guards and redirect validation.

## Exposure

Reached only as a transitive **dev** dependency:

```
fast-uri <- ajv 8.20.0 <- schema-utils <- css-minimizer-webpack-plugin
                                       <- webpack / webpack-dev-server
                                       <- mini-css-extract-plugin
```

Every path terminates in `devDependencies`, and the lockfile marks both `ajv` and `fast-uri` dev-only. GitHub classifies alert #258 as *Development* scope for the same reason. There is no production runtime exposure, which is why the `audit-ci` gate (`skip-dev: true`) stayed green through the vulnerable window rather than the gate having failed to fire.

## Why `overrides` rather than `npm update`

`ajv` declares `fast-uri: ^3.0.1`. A plain update would satisfy the alert today but leave a future lockfile regeneration free to resolve back below `3.1.5`. The `overrides` pin holds the floor.

`3.1.5` rather than `4.1.2` because 4.x is outside `ajv`'s declared range.

## Verification

Rebuilt from a clean checkout of this branch (`npm ci`, Node 22):

- `fast-uri@3.1.5`, single copy in the tree, marked `overridden`
- `npm audit` — 0 vulnerabilities
- `npm run build` — webpack 5.108.4 compiled, only the pre-existing bundle-size warnings
- `npx audit-ci@^7 --config ./audit-ci.jsonc` — passed, allowlist still empty (no new deferral added)

Note that `.github/workflows/security.yml` triggers on `pull_request` and pushes to `master`, so commit b78eae3 has had no CI run of its own until now — opening this PR is what validates the branch.